### PR TITLE
Update Course.java

### DIFF
--- a/src/main/java/LMS/LearningManagementSystem/model/Course.java
+++ b/src/main/java/LMS/LearningManagementSystem/model/Course.java
@@ -76,6 +76,7 @@ public class Course {
     }
 
     public void setMediaFiles(ArrayList<Object> objects) {
+        throw new UnsupportedOperationException("setMediaFiles is not supported. Modify the mediaFiles list directly.");
     }
 
     public void setId(Integer courseId) {


### PR DESCRIPTION
An empty method is generally considered bad practice and can lead to confusion, readability, and maintenance issues. Empty methods bring no functionality and are misleading to others as they might think the method implementation fulfills a specific and identified requirement. There are several reasons for a method not to have a body: It is an unintentional omission, and should be fixed to prevent an unexpected behavior in production. It is not yet, or never will be, supported. In this case an exception should be thrown. The method is an intentionally-blank override. In this case a nested comment should explain the reason for the blank override.