### PR TITLE
Update Student.java

### DIFF
--- a/src/main/java/LMS/LearningManagementSystem/model/Student.java
+++ b/src/main/java/LMS/LearningManagementSystem/model/Student.java
@@ -23,7 +23,7 @@ public class Student extends User {
             joinColumns = @JoinColumn(name = "student_id"),
             inverseJoinColumns = @JoinColumn(name = "course_id")
     )
-    private List<Course> courses;
+    private transient List<Course> courses;
     @Enumerated(EnumType.STRING)
     private Role role ;
 


### PR DESCRIPTION
By contract, non-static fields in a Serializable class must themselves be either Serializable or transient. Even if the class is never explicitly serialized or deserialized, it is not safe to assume that this cannot happen. For instance, under load, most J2EE application frameworks flush objects to disk. An object that implements Serializable but contains non-transient, non-serializable data members (and thus violates the contract) could cause application crashes and open the door to attackers. In general, a Serializable class is expected to fulfil its contract and not exhibit unexpected behaviour when an instance is serialized. This rule raises an issue on:
Non-Serializable fields.
When a field is assigned a non-Serializable type within the class. Collection fields when they are not private. Values that are not serializable could be added to these collections externally. Due to type erasure, it cannot be guaranteed that the collection will only contain serializable objects at runtime despite being declared as a collection of serializable types.